### PR TITLE
Honor upload.duplicates config

### DIFF
--- a/lib/clouddrive/commands/upload_command.rb
+++ b/lib/clouddrive/commands/upload_command.rb
@@ -28,9 +28,7 @@ module CloudDrive
       if File.directory?(source)
         Node.upload_dir(source, remote_path, overwrite, method(:display_file_results))
       else
-        result = Node.upload_file(source, remote_path, {
-          :overwrite => overwrite
-        })
+        result = Node.upload_file(source, remote_path, :overwrite => overwrite)
         display_file_results(source, remote_path, result)
       end
     end

--- a/lib/clouddrive/commands/upload_command.rb
+++ b/lib/clouddrive/commands/upload_command.rb
@@ -28,7 +28,9 @@ module CloudDrive
       if File.directory?(source)
         Node.upload_dir(source, remote_path, overwrite, method(:display_file_results))
       else
-        result = Node.upload_file(source, remote_path, overwrite)
+        result = Node.upload_file(source, remote_path, {
+          :overwrite => overwrite
+        })
         display_file_results(source, remote_path, result)
       end
     end

--- a/lib/clouddrive/commands/upload_command.rb
+++ b/lib/clouddrive/commands/upload_command.rb
@@ -26,7 +26,7 @@ module CloudDrive
       end
 
       if File.directory?(source)
-        Node.upload_dir(source, remote_path, overwrite, method(:display_file_results))
+        Node.upload_dir(source, remote_path, method(:display_file_results), :overwrite => overwrite)
       else
         result = Node.upload_file(source, remote_path, :overwrite => overwrite)
         display_file_results(source, remote_path, result)

--- a/lib/clouddrive/commands/upload_command.rb
+++ b/lib/clouddrive/commands/upload_command.rb
@@ -25,10 +25,11 @@ module CloudDrive
         overwrite = false
       end
 
+      options = { :overwrite => overwrite, :allow_duplicates => @config['upload.duplicates'] }
       if File.directory?(source)
-        Node.upload_dir(source, remote_path, method(:display_file_results), :overwrite => overwrite)
+        Node.upload_dir(source, remote_path, method(:display_file_results), options)
       else
-        result = Node.upload_file(source, remote_path, :overwrite => overwrite)
+        result = Node.upload_file(source, remote_path, options)
         display_file_results(source, remote_path, result)
       end
     end

--- a/lib/clouddrive/node.rb
+++ b/lib/clouddrive/node.rb
@@ -551,7 +551,9 @@ module CloudDrive
         path_info = Pathname.new(file)
         remote_dest = path_info.dirname.sub(src_path, dest_root).to_s
 
-        result = Node.upload_file(file, remote_dest, overwrite)
+        result = Node.upload_file(file, remote_dest, {
+          :overwrite => overwrite
+        })
 
         unless result[:success]
           if result[:status_code] === 401
@@ -582,7 +584,7 @@ module CloudDrive
       retval
     end
 
-    def self.upload_file(src_path, dest_path, overwrite = false)
+    def self.upload_file(src_path, dest_path, options = {})
       retval = {
           :success => false,
           :data => {},
@@ -613,7 +615,7 @@ module CloudDrive
         end
 
         if path_match && !md5_match
-          if overwrite
+          if options[:overwrite]
             return result[:data]["node"].overwrite(src_path)
           end
 

--- a/lib/clouddrive/node.rb
+++ b/lib/clouddrive/node.rb
@@ -608,6 +608,7 @@ module CloudDrive
         if md5_match && path_match
           # Skip if path and MD5 match
           retval[:data] = result[:data]
+          retval[:success] = true
 
           return retval
         end

--- a/lib/clouddrive/node.rb
+++ b/lib/clouddrive/node.rb
@@ -551,9 +551,7 @@ module CloudDrive
         path_info = Pathname.new(file)
         remote_dest = path_info.dirname.sub(src_path, dest_root).to_s
 
-        result = Node.upload_file(file, remote_dest, {
-          :overwrite => overwrite
-        })
+        result = Node.upload_file(file, remote_dest, :overwrite => overwrite)
 
         unless result[:success]
           if result[:status_code] === 401

--- a/lib/clouddrive/node.rb
+++ b/lib/clouddrive/node.rb
@@ -536,7 +536,7 @@ module CloudDrive
       @@cache.search_nodes_by_name(name)
     end
 
-    def self.upload_dir(src_path, dest_root, overwrite = false, callback = nil)
+    def self.upload_dir(src_path, dest_root, callback = nil, options = {})
       src_path = File.expand_path(src_path)
 
       dest_root = Node.get_path_array(dest_root)
@@ -551,7 +551,7 @@ module CloudDrive
         path_info = Pathname.new(file)
         remote_dest = path_info.dirname.sub(src_path, dest_root).to_s
 
-        result = Node.upload_file(file, remote_dest, :overwrite => overwrite)
+        result = Node.upload_file(file, remote_dest, options)
 
         unless result[:success]
           if result[:status_code] === 401

--- a/lib/clouddrive/node.rb
+++ b/lib/clouddrive/node.rb
@@ -624,9 +624,7 @@ module CloudDrive
           return retval
         end
 
-        if !path_match && md5_match
-          # If path doesn't match but MD5 does, check if we allow deduping
-          # @TODO: finish this!
+        if !path_match && md5_match && !options[:allow_duplicates]
           retval[:data] = result[:data]
 
           return retval

--- a/lib/clouddrive/node.rb
+++ b/lib/clouddrive/node.rb
@@ -642,7 +642,7 @@ module CloudDrive
           :content => File.new(File.expand_path(src_path), 'rb')
       }
 
-      RestClient.post("#{@@account.content_url}nodes", body, :Authorization => "Bearer #{@@account.token_store[:access_token]}") do |response, request, result|
+      RestClient.post("#{@@account.content_url}nodes", body, :Authorization => "Bearer #{@@account.token_store[:access_token]}") do |response|
         retval[:data] = JSON.parse(response.body)
         retval[:status_code] = response.code
         if response.code === 201

--- a/spec/clouddrive/commands/upload_command_spec.rb
+++ b/spec/clouddrive/commands/upload_command_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'json'
+
+describe CloudDrive::UploadCommand do
+  describe '#execute' do
+    let(:command) { CloudDrive::UploadCommand.new '.' }
+    let(:config_file_location) { %r{/\.cache/clouddrive-ruby/config\.json\z} }
+    let(:config) { {} }
+    let(:src_path) { '/src/path' }
+    let(:remote_path) { 'remote/path' }
+    let(:results_method) { command.method :display_file_results }
+    before do
+      allow(File).to receive(:exists?).with(config_file_location).and_return true
+      allow(File).to receive(:read).with(config_file_location).and_return config.to_json
+      allow(CloudDrive::Sqlite).to receive(:new).and_return double(CloudDrive::Sqlite)
+      allow(CloudDrive::Account).to receive(:new).and_return double(CloudDrive::Account, :authorize => { :success => true })
+      allow(CloudDrive::Node).to receive :init
+      allow(File).to receive(:exists?).with(src_path).and_return true
+    end
+    context 'uploading a directory without passing the --overwrite option' do
+      it do
+        expect(File).to receive(:directory?).with(src_path).and_return true
+        expect(CloudDrive::Node).to receive(:upload_dir).with src_path, remote_path, results_method, :overwrite => false, :allow_duplicates => false
+
+        command.run [src_path, remote_path]
+      end
+    end
+
+    context 'uploading a directory and passing the --overwrite option' do
+      it do
+        expect(File).to receive(:directory?).with(src_path).and_return true
+        expect(CloudDrive::Node).to receive(:upload_dir).with src_path, remote_path, results_method, :overwrite => true, :allow_duplicates => false
+
+        command.run ['--overwrite', src_path, remote_path]
+      end
+    end
+
+    context 'uploading a directory when config[upload.duplicates] == true' do
+      let(:config) { { 'upload.duplicates' => true } }
+      it do
+        expect(File).to receive(:directory?).with(src_path).and_return true
+        expect(CloudDrive::Node).to receive(:upload_dir).with src_path, remote_path, results_method, :overwrite => false, :allow_duplicates => true
+
+        command.run [src_path, remote_path]
+      end
+    end
+
+    context 'uploading a file without passing the --overwrite option' do
+      it do
+        expect(File).to receive(:directory?).with(src_path).and_return false
+        expect(CloudDrive::Node).
+          to receive(:upload_file).
+          with(src_path, remote_path, :overwrite => false, :allow_duplicates => false).
+          and_return :success => true
+
+        command.run [src_path, remote_path]
+      end
+    end
+
+    context 'uploading a file and passing the --overwrite option' do
+      it do
+        expect(File).to receive(:directory?).with(src_path).and_return false
+        expect(CloudDrive::Node).
+          to receive(:upload_file).
+          with(src_path, remote_path, :overwrite => true, :allow_duplicates => false).
+          and_return :success => true
+
+        command.run ['--overwrite', src_path, remote_path]
+      end
+    end
+
+    context 'uploading a file when config[upload.duplicates] == true' do
+      let(:config) { { 'upload.duplicates' => true } }
+      it do
+        expect(File).to receive(:directory?).with(src_path).and_return false
+        expect(CloudDrive::Node).
+          to receive(:upload_file).
+          with(src_path, remote_path, :overwrite => false, :allow_duplicates => true).
+          and_return :success => true
+
+        command.run [src_path, remote_path]
+      end
+    end
+  end
+end

--- a/spec/clouddrive/commands/upload_command_spec.rb
+++ b/spec/clouddrive/commands/upload_command_spec.rb
@@ -10,12 +10,12 @@ describe CloudDrive::UploadCommand do
     let(:remote_path) { 'remote/path' }
     let(:results_method) { command.method :display_file_results }
     before do
-      allow(File).to receive(:exists?).with(config_file_location).and_return true
+      allow(File).to receive(:exist?).with(config_file_location).and_return true
       allow(File).to receive(:read).with(config_file_location).and_return config.to_json
       allow(CloudDrive::Sqlite).to receive(:new).and_return double(CloudDrive::Sqlite)
       allow(CloudDrive::Account).to receive(:new).and_return double(CloudDrive::Account, :authorize => { :success => true })
       allow(CloudDrive::Node).to receive :init
-      allow(File).to receive(:exists?).with(src_path).and_return true
+      allow(File).to receive(:exist?).with(src_path).and_return true
     end
     context 'uploading a directory without passing the --overwrite option' do
       it do

--- a/spec/clouddrive/node_spec.rb
+++ b/spec/clouddrive/node_spec.rb
@@ -46,6 +46,31 @@ describe CloudDrive::Node do
       end
     end
 
+    context 'when MD5 matches and Path does not match and options[:allow_duplicates] == true' do
+      let(:exists_return) do
+        {
+          :success => true,
+          :data => success_data
+        }
+      end
+      let(:success_data) do
+        {
+          'md5_match' => true,
+          'path_match' => false
+        }
+      end
+      before { CloudDrive::Node.class_variable_set :@@account, double(CloudDrive::Account, :content_url => 'content url', :token_store => {}) }
+      after { CloudDrive::Node.class_variable_set :@@account, nil }
+      it do
+        expect(File).to receive(:new).with(src_path, 'rb').and_return double(File)
+        expect(RestClient).to receive :post
+
+        CloudDrive::Node.upload_file(src_path, dest_path, {
+          :allow_duplicates => true
+        })
+      end
+    end
+
     context 'when MD5 does not match and Path matches' do
       let(:exists_return) do
         {

--- a/spec/clouddrive/node_spec.rb
+++ b/spec/clouddrive/node_spec.rb
@@ -15,9 +15,14 @@ describe CloudDrive::Node do
       after { CloudDrive::Node.class_variable_set :@@account, nil }
       it do
         expect(File).to receive(:new).with(src_path, 'rb').and_return double(File)
-        expect(RestClient).to receive :post
+        expect(RestClient).to receive(:post).and_yield double(RestClient::Response, :body => '{}', :code => 201)
+        expect(CloudDrive::Node).to receive(:new).with({}).and_return(double(CloudDrive::Node, :save => nil))
 
-        CloudDrive::Node.upload_file src_path, dest_path
+        expect(CloudDrive::Node.upload_file(src_path, dest_path)).to eq({
+          :success => true,
+          :data => {},
+          :status_code => 201
+        })
       end
     end
 
@@ -63,10 +68,13 @@ describe CloudDrive::Node do
       after { CloudDrive::Node.class_variable_set :@@account, nil }
       it do
         expect(File).to receive(:new).with(src_path, 'rb').and_return double(File)
-        expect(RestClient).to receive :post
+        expect(RestClient).to receive(:post).and_yield double(RestClient::Response, :body => '{}', :code => 201)
+        expect(CloudDrive::Node).to receive(:new).with({}).and_return(double(CloudDrive::Node, :save => nil))
 
-        CloudDrive::Node.upload_file(src_path, dest_path, {
-          :allow_duplicates => true
+        expect(CloudDrive::Node.upload_file(src_path, dest_path, :allow_duplicates => true)).to eq({
+          :success => true,
+          :data => {},
+          :status_code => 201
         })
       end
     end

--- a/spec/clouddrive/node_spec.rb
+++ b/spec/clouddrive/node_spec.rb
@@ -6,7 +6,7 @@ describe CloudDrive::Node do
     let(:src_path) { '/root/srcpath' }
     let(:src_file_path) { "#{src_path}/#{filename}" }
     let(:dest_path) { 'dest/path' }
-    context 'happy path' do
+    context 'without passing overwrite argument' do
       before { CloudDrive::Node.class_variable_set :@@account, double(CloudDrive::Account, :token_store => { :last_authorized => Time.new.to_i + 1000 }) }
       after { CloudDrive::Node.class_variable_set :@@account, nil }
       it do
@@ -15,6 +15,18 @@ describe CloudDrive::Node do
           :success => true
         )
         expect(CloudDrive::Node.upload_dir(src_path, dest_path)).to eq [:success => true]
+      end
+    end
+
+    context 'with overwrite argument == true' do
+      before { CloudDrive::Node.class_variable_set :@@account, double(CloudDrive::Account, :token_store => { :last_authorized => Time.new.to_i + 1000 }) }
+      after { CloudDrive::Node.class_variable_set :@@account, nil }
+      it do
+        expect(Find).to receive(:find).and_yield src_file_path
+        expect(CloudDrive::Node).to receive(:upload_file).with(src_file_path, "#{dest_path}/srcpath", :overwrite => true).and_return(
+          :success => true
+        )
+        expect(CloudDrive::Node.upload_dir(src_path, dest_path, true)).to eq [:success => true]
       end
     end
   end

--- a/spec/clouddrive/node_spec.rb
+++ b/spec/clouddrive/node_spec.rb
@@ -6,7 +6,7 @@ describe CloudDrive::Node do
     let(:src_path) { '/root/srcpath' }
     let(:src_file_path) { "#{src_path}/#{filename}" }
     let(:dest_path) { 'dest/path' }
-    context 'without passing overwrite argument' do
+    context 'without passing options' do
       before { CloudDrive::Node.class_variable_set :@@account, double(CloudDrive::Account, :token_store => { :last_authorized => Time.new.to_i + 1000 }) }
       after { CloudDrive::Node.class_variable_set :@@account, nil }
       it do
@@ -18,15 +18,15 @@ describe CloudDrive::Node do
       end
     end
 
-    context 'with overwrite argument == true' do
+    context 'with passing options' do
       before { CloudDrive::Node.class_variable_set :@@account, double(CloudDrive::Account, :token_store => { :last_authorized => Time.new.to_i + 1000 }) }
       after { CloudDrive::Node.class_variable_set :@@account, nil }
       it do
         expect(Find).to receive(:find).and_yield src_file_path
-        expect(CloudDrive::Node).to receive(:upload_file).with(src_file_path, "#{dest_path}/srcpath", :overwrite => true).and_return(
+        expect(CloudDrive::Node).to receive(:upload_file).with(src_file_path, "#{dest_path}/srcpath", :overwrite => true, :allow_duplicates => true).and_return(
           :success => true
         )
-        expect(CloudDrive::Node.upload_dir(src_path, dest_path, nil, :overwrite => true)).to eq [:success => true]
+        expect(CloudDrive::Node.upload_dir(src_path, dest_path, nil, :overwrite => true, :allow_duplicates => true)).to eq [:success => true]
       end
     end
   end

--- a/spec/clouddrive/node_spec.rb
+++ b/spec/clouddrive/node_spec.rb
@@ -1,6 +1,24 @@
 require 'spec_helper'
 
 describe CloudDrive::Node do
+  describe '.upload_dir' do
+    let(:filename) { 'filename' }
+    let(:src_path) { '/root/srcpath' }
+    let(:src_file_path) { "#{src_path}/#{filename}" }
+    let(:dest_path) { 'dest/path' }
+    context 'happy path' do
+      before { CloudDrive::Node.class_variable_set :@@account, double(CloudDrive::Account, :token_store => { :last_authorized => Time.new.to_i + 1000 }) }
+      after { CloudDrive::Node.class_variable_set :@@account, nil }
+      it do
+        expect(Find).to receive(:find).and_yield src_file_path
+        expect(CloudDrive::Node).to receive(:upload_file).with(src_file_path, "#{dest_path}/srcpath", :overwrite => false).and_return(
+          :success => true
+        )
+        expect(CloudDrive::Node.upload_dir(src_path, dest_path)).to eq [:success => true]
+      end
+    end
+  end
+
   describe '.upload_file' do
     let(:filename) { 'filename' }
     let(:src_path) { "/src/path/to/#{filename}" }

--- a/spec/clouddrive/node_spec.rb
+++ b/spec/clouddrive/node_spec.rb
@@ -11,7 +11,7 @@ describe CloudDrive::Node do
       after { CloudDrive::Node.class_variable_set :@@account, nil }
       it do
         expect(Find).to receive(:find).and_yield src_file_path
-        expect(CloudDrive::Node).to receive(:upload_file).with(src_file_path, "#{dest_path}/srcpath", :overwrite => false).and_return(
+        expect(CloudDrive::Node).to receive(:upload_file).with(src_file_path, "#{dest_path}/srcpath", {}).and_return(
           :success => true
         )
         expect(CloudDrive::Node.upload_dir(src_path, dest_path)).to eq [:success => true]
@@ -26,7 +26,7 @@ describe CloudDrive::Node do
         expect(CloudDrive::Node).to receive(:upload_file).with(src_file_path, "#{dest_path}/srcpath", :overwrite => true).and_return(
           :success => true
         )
-        expect(CloudDrive::Node.upload_dir(src_path, dest_path, true)).to eq [:success => true]
+        expect(CloudDrive::Node.upload_dir(src_path, dest_path, nil, :overwrite => true)).to eq [:success => true]
       end
     end
   end

--- a/spec/clouddrive/node_spec.rb
+++ b/spec/clouddrive/node_spec.rb
@@ -71,7 +71,7 @@ describe CloudDrive::Node do
       end
     end
 
-    context 'when MD5 does not match and Path matches and overwrite == true' do
+    context 'when MD5 does not match and Path matches and options[:overwrite] == true' do
       let(:node_double) { double(CloudDrive::Node) }
       let(:exists_return) do
         {
@@ -91,7 +91,9 @@ describe CloudDrive::Node do
         expect(File).not_to receive :new
         expect(RestClient).not_to receive :post
 
-        expect(CloudDrive::Node.upload_file(src_path, dest_path, true)).to eq({})
+        expect(CloudDrive::Node.upload_file(src_path, dest_path, {
+          :overwrite => true
+        })).to eq({})
       end
     end
   end

--- a/spec/clouddrive/node_spec.rb
+++ b/spec/clouddrive/node_spec.rb
@@ -36,11 +36,11 @@ describe CloudDrive::Node do
         expect(RestClient).to receive(:post).and_yield double(RestClient::Response, :body => '{}', :code => 201)
         expect(CloudDrive::Node).to receive(:new).with({}).and_return(double(CloudDrive::Node, :save => nil))
 
-        expect(CloudDrive::Node.upload_file(src_path, dest_path)).to eq({
+        expect(CloudDrive::Node.upload_file(src_path, dest_path)).to eq(
           :success => true,
           :data => {},
           :status_code => 201
-        })
+        )
       end
     end
 
@@ -53,11 +53,11 @@ describe CloudDrive::Node do
         expect(RestClient).to receive(:post).and_yield double(RestClient::Response, :body => '{}', :code => 500)
         expect(CloudDrive::Node).not_to receive :new
 
-        expect(CloudDrive::Node.upload_file(src_path, dest_path)).to eq({
+        expect(CloudDrive::Node.upload_file(src_path, dest_path)).to eq(
           :success => false,
           :data => {},
           :status_code => 500
-        })
+        )
       end
     end
 
@@ -78,11 +78,11 @@ describe CloudDrive::Node do
         expect(File).not_to receive :new
         expect(RestClient).not_to receive :post
 
-        expect(CloudDrive::Node.upload_file(src_path, dest_path)).to eq({
+        expect(CloudDrive::Node.upload_file(src_path, dest_path)).to eq(
           :success => false,
           :data => success_data,
           :status_code => nil
-        })
+        )
       end
     end
 
@@ -106,11 +106,11 @@ describe CloudDrive::Node do
         expect(RestClient).to receive(:post).and_yield double(RestClient::Response, :body => '{}', :code => 201)
         expect(CloudDrive::Node).to receive(:new).with({}).and_return(double(CloudDrive::Node, :save => nil))
 
-        expect(CloudDrive::Node.upload_file(src_path, dest_path, :allow_duplicates => true)).to eq({
+        expect(CloudDrive::Node.upload_file(src_path, dest_path, :allow_duplicates => true)).to eq(
           :success => true,
           :data => {},
           :status_code => 201
-        })
+        )
       end
     end
 
@@ -131,11 +131,11 @@ describe CloudDrive::Node do
         expect(File).not_to receive :new
         expect(RestClient).not_to receive :post
 
-        expect(CloudDrive::Node.upload_file(src_path, dest_path)).to eq({
+        expect(CloudDrive::Node.upload_file(src_path, dest_path)).to eq(
           :success => false,
           :data => success_data,
           :status_code => nil
-        })
+        )
       end
     end
 

--- a/spec/clouddrive/node_spec.rb
+++ b/spec/clouddrive/node_spec.rb
@@ -26,6 +26,23 @@ describe CloudDrive::Node do
       end
     end
 
+    context 'when MD5 and Path do not match and the upload is not successful' do
+      let(:exists_return) { {} }
+      before { CloudDrive::Node.class_variable_set :@@account, double(CloudDrive::Account, :content_url => 'content url', :token_store => {}) }
+      after { CloudDrive::Node.class_variable_set :@@account, nil }
+      it do
+        expect(File).to receive(:new).with(src_path, 'rb').and_return double(File)
+        expect(RestClient).to receive(:post).and_yield double(RestClient::Response, :body => '{}', :code => 500)
+        expect(CloudDrive::Node).not_to receive :new
+
+        expect(CloudDrive::Node.upload_file(src_path, dest_path)).to eq({
+          :success => false,
+          :data => {},
+          :status_code => 500
+        })
+      end
+    end
+
     context 'when MD5 matches and Path does not match' do
       let(:exists_return) do
         {

--- a/spec/clouddrive/node_spec.rb
+++ b/spec/clouddrive/node_spec.rb
@@ -124,9 +124,7 @@ describe CloudDrive::Node do
         expect(File).not_to receive :new
         expect(RestClient).not_to receive :post
 
-        expect(CloudDrive::Node.upload_file(src_path, dest_path, {
-          :overwrite => true
-        })).to eq({})
+        expect(CloudDrive::Node.upload_file(src_path, dest_path, :overwrite => true)).to eq({})
       end
     end
   end

--- a/spec/clouddrive/node_spec.rb
+++ b/spec/clouddrive/node_spec.rb
@@ -98,6 +98,31 @@ describe CloudDrive::Node do
       end
     end
 
+    context 'when MD5 and Path match' do
+      let(:exists_return) do
+        {
+          :success => true,
+          :data => success_data
+        }
+      end
+      let(:success_data) do
+        {
+          'md5_match' => true,
+          'path_match' => true
+        }
+      end
+      it do
+        expect(File).not_to receive :new
+        expect(RestClient).not_to receive :post
+
+        expect(CloudDrive::Node.upload_file(src_path, dest_path)).to eq(
+          :success => true,
+          :data => success_data,
+          :status_code => nil
+        )
+      end
+    end
+
     context 'when MD5 matches and Path does not match and options[:allow_duplicates] == true' do
       let(:exists_return) do
         {

--- a/spec/clouddrive/node_spec.rb
+++ b/spec/clouddrive/node_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe CloudDrive::Node do
+  describe '.upload_file' do
+    let(:filename) { 'filename' }
+    let(:src_path) { "/src/path/to/#{filename}" }
+    let(:dest_path) { 'dest/path' }
+    before do
+      expect(CloudDrive::Node).to receive(:load_by_path).with(dest_path).and_return double(CloudDrive::Node, :get_id => 'an id')
+      expect(CloudDrive::Node).to receive(:exists?).with("#{dest_path}/#{filename}", src_path).and_return exists_return
+    end
+    context 'when MD5 and Path do not match' do
+      let(:exists_return) { {} }
+      before { CloudDrive::Node.class_variable_set :@@account, double(CloudDrive::Account, :content_url => 'content url', :token_store => {}) }
+      after { CloudDrive::Node.class_variable_set :@@account, nil }
+      it do
+        expect(File).to receive(:new).with(src_path, 'rb').and_return double(File)
+        expect(RestClient).to receive :post
+
+        CloudDrive::Node.upload_file src_path, dest_path
+      end
+    end
+
+    context 'when MD5 matches and Path does not match' do
+      let(:exists_return) do
+        {
+          :success => true,
+          :data => success_data
+        }
+      end
+      let(:success_data) do
+        {
+          'md5_match' => true,
+          'path_match' => false
+        }
+      end
+      it do
+        expect(File).not_to receive :new
+        expect(RestClient).not_to receive :post
+
+        expect(CloudDrive::Node.upload_file(src_path, dest_path)).to eq({
+          :success => false,
+          :data => success_data,
+          :status_code => nil
+        })
+      end
+    end
+
+    context 'when MD5 does not match and Path matches' do
+      let(:exists_return) do
+        {
+          :success => true,
+          :data => success_data
+        }
+      end
+      let(:success_data) do
+        {
+          'md5_match' => false,
+          'path_match' => true
+        }
+      end
+      it do
+        expect(File).not_to receive :new
+        expect(RestClient).not_to receive :post
+
+        expect(CloudDrive::Node.upload_file(src_path, dest_path)).to eq({
+          :success => false,
+          :data => success_data,
+          :status_code => nil
+        })
+      end
+    end
+
+    context 'when MD5 does not match and Path matches and overwrite == true' do
+      let(:node_double) { double(CloudDrive::Node) }
+      let(:exists_return) do
+        {
+          :success => true,
+          :data => success_data
+        }
+      end
+      let(:success_data) do
+        {
+          'md5_match' => false,
+          'path_match' => true,
+          'node' => node_double
+        }
+      end
+      it do
+        expect(node_double).to receive(:overwrite).with(src_path).and_return({})
+        expect(File).not_to receive :new
+        expect(RestClient).not_to receive :post
+
+        expect(CloudDrive::Node.upload_file(src_path, dest_path, true)).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi there! I made one more change to honor the `upload.duplicates` setting. Based on your `TODO` it looked like this was something you were planning to implement and I needed it for my use case. Hopefully this is along the lines of what you're looking for but please let me know if you'd like anything changed.

I also made a small change to not consider a path **and** md5 match where the upload is skipped as an error, since it's really just a bandwidth-saving measure. This is along the lines of e.g. `rspec`. Just let me know if you want me to change that back or add a config option for it.

Thanks again for the library, it's working great for me!