### PR TITLE
Suppress deduplication

### DIFF
--- a/lib/clouddrive/node.rb
+++ b/lib/clouddrive/node.rb
@@ -641,7 +641,9 @@ module CloudDrive
           :content => File.new(File.expand_path(src_path), 'rb')
       }
 
-      RestClient.post("#{@@account.content_url}nodes", body, :Authorization => "Bearer #{@@account.token_store[:access_token]}") do |response|
+      url = "#{@@account.content_url}nodes"
+      url = "#{url}?suppress=deduplication" if options[:allow_duplicates]
+      RestClient.post(url, body, :Authorization => "Bearer #{@@account.token_store[:access_token]}") do |response|
         retval[:data] = JSON.parse(response.body)
         retval[:status_code] = response.code
         if response.code === 201

--- a/lib/clouddrive/version.rb
+++ b/lib/clouddrive/version.rb
@@ -1,3 +1,3 @@
 module CloudDrive
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
As recommended by the API docs, pass "?suppress=deduplication" to avoid `Attempted to upload a duplicate File` errors when uploading duplicate files. See "Upload File" here:
https://developer.amazon.com/public/apis/experience/cloud-drive/content/nodes